### PR TITLE
Match keeps a copy of the input string, but input string mutates. 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/rundeck/RundeckNotifier.java
@@ -230,7 +230,7 @@ public class RundeckNotifier extends Notifier {
         // http://groups.google.com/group/rundeck-discuss/browse_thread/thread/94a6833b84fdc10b
         Matcher matcher = TOKEN_ARTIFACT_NAME_PATTERN.matcher(input);
         int idx = 0;
-        while (matcher.find(idx)) {
+        while (matcher.reset(input).find(idx)) {
             idx = matcher.end();
             String regex = matcher.group(1);
             Pattern pattern = Pattern.compile(regex);


### PR DESCRIPTION
Match keeps a copy of the input string, but input string mutates. Reset matcher on each loop. Fixes #3.
